### PR TITLE
Integrate Google Trends hourly collector with context nodes

### DIFF
--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -44,6 +44,7 @@ pyasn1~=0.6
 pyasn1_modules~=0.4
 pyee~=13.0
 pyparsing~=3.2
+pytrends~=4.9
 python-dateutil~=2.9
 python-dotenv~=1.1
 PyYAML~=6.0

--- a/src/collectors/google_trends.py
+++ b/src/collectors/google_trends.py
@@ -1,0 +1,93 @@
+from datetime import datetime
+import time
+import re
+
+try:
+    from pytrends.request import TrendReq
+except Exception:  # ImportError or other errors
+    TrendReq = None
+
+
+def _slugify(text: str) -> str:
+    """Normalize text to a slug usable as node ids."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+
+def start_google_trends_collector(on_event=None, region: str = "US", category: str = "all", count: int = 20, interval: int = 3600):
+    """Poll Google Trends' realtime trending searches every ``interval`` seconds.
+
+    Parameters
+    ----------
+    on_event: callable
+        Callback to handle each emitted event.
+    region: str
+        Two-letter region code, e.g. ``"US"``.
+    category: str
+        Trend category. ``"all"`` to get all categories.
+    count: int
+        Number of results to process from the API.
+    interval: int
+        Seconds between polls. Defaults to one hour.
+    """
+    if TrendReq is None:
+        raise ImportError("pytrends is required for the Google Trends collector")
+
+    print("[Google Trends Collector] Starting stream...")
+    pytrends = TrendReq(hl="en-US", tz=360)
+
+    while True:
+        try:
+            df = pytrends.realtime_trending_searches(pn=region, cat=category, count=count)
+            for _, row in df.iterrows():
+                data = row.to_dict()
+                term = data.get("query") or data.get("title")
+                if not term:
+                    continue
+                contexts = []
+                entity_names = data.get("entityNames")
+                if isinstance(entity_names, list):
+                    contexts.extend([str(c) for c in entity_names])
+                articles = data.get("articles")
+                if isinstance(articles, list):
+                    for art in articles:
+                        title = art.get("title") if isinstance(art, dict) else str(art)
+                        if title:
+                            contexts.append(title)
+                event = {
+                    "timestamp": datetime.utcnow().isoformat(),
+                    "content_id": f"trend_{_slugify(term)}",
+                    "source": "google_trends",
+                    "type": "trend",
+                    "text": term,
+                    "context": contexts,
+                }
+                if on_event:
+                    on_event(event)
+                else:
+                    print(event)
+        except Exception as e:
+            print(f"[Google Trends Collector] Error fetching trends: {e}")
+        time.sleep(interval)
+
+
+def fake_google_trends_stream(on_event=None, n_events: int = 5, delay: float = 1.0):
+    """Emit synthetic Google Trends events for offline testing."""
+    print("[Fake Google Trends Stream] Starting simulation...")
+    for i in range(n_events):
+        term = f"Example Trend {i}"
+        event = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "content_id": f"trend_{_slugify(term)}",
+            "source": "google_trends",
+            "type": "trend",
+            "text": term,
+            "context": [f"Context {i}", "General News"],
+        }
+        if on_event:
+            on_event(event)
+        else:
+            print(event)
+        time.sleep(delay)
+    print("[Fake Google Trends Stream] Finished emitting events.")

--- a/src/graph/builder.py
+++ b/src/graph/builder.py
@@ -38,6 +38,8 @@ class GraphBuilder:
             return "tiktok_video"
         if node.startswith("trend_"):
             return "trend"
+        if node.startswith("ctx_"):
+            return "context"
         # TODO: Add more types
         return "unknown"
 

--- a/src/utils/event_parser.py
+++ b/src/utils/event_parser.py
@@ -1,5 +1,15 @@
+import re
+
+
+def _slugify(text: str) -> str:
+    """Utility: convert free text into a safe identifier."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+
 def parse_event(event):
-    """ Parse a raw event into structured components for graph processing.
+    """Parse a raw event into structured components for graph processing.
     Standardizes identifiers and timestamps across platforms (user IDs, tweet IDs, video IDs).
     """
     source = event.get("source")
@@ -36,7 +46,11 @@ def parse_event(event):
             outputs.append(("user-commented", user, content, "commented"))
 
     elif source == "google_trends":
-        # Context/trend nodes (e.g. for trend-topic or breaking event)
+        # Trend node itself
         outputs.append(("trend-event", None, content, "trend"))
+        # Optional context nodes for disambiguation
+        for ctx in event.get("context", []):
+            ctx_id = f"ctx_{_slugify(ctx)}"
+            outputs.append(("trend-context", content, ctx_id, "has_context"))
 
     return outputs

--- a/test/test_google_trends_parser.py
+++ b/test/test_google_trends_parser.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+# Ensure src is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from utils.event_parser import parse_event
+
+
+def test_google_trends_context_parsing():
+    event = {
+        "timestamp": "2025-01-01T00:00:00",
+        "source": "google_trends",
+        "type": "trend",
+        "content_id": "trend_sample_term",
+        "context": ["Breaking News", "Some Article"],
+    }
+    edges = parse_event(event)
+    assert ("trend-event", None, "trend_sample_term", "trend") in edges
+    context_edges = [e for e in edges if e[0] == "trend-context"]
+    assert len(context_edges) == 2
+    assert all(e[1] == "trend_sample_term" for e in context_edges)
+    assert {e[2] for e in context_edges} == {"ctx_breaking_news", "ctx_some_article"}


### PR DESCRIPTION
## Summary
- add Google Trends realtime collector using pytrends
- parse trend context into graph edges and support context node types
- add unit test for Google Trends context parsing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy -q` *(fails: Could not find a version that satisfies the requirement numpy)*
- `pytest test/test_google_trends_parser.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68afc13082a88323b57c5412d582361a