### PR TITLE
Centralise configuration and add schemas

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,6 @@
+"""Central configuration package."""
+
+from .config import *  # noqa: F401,F403
+from .schemas import *  # noqa: F401,F403
+
+__all__ = []

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+"""Project-wide configuration constants."""
+
+# Online evaluation
+DELTA_HOURS: int = 2         # Δ
+WINDOW_MIN: int = 60         # W
+K_DEFAULT: int = 5
+K_OPTIONS: tuple[int, ...] = (5, 10)
+
+# SLOs
+SLO_MED_MS: int = 1000
+SLO_P95_MS: int = 2000
+
+# Embeddings / preprocessing budgets
+EMBEDDER_P95_CPU_MS: int = 100
+EMBED_PREPROC_BUDGET_MS: int = 200  # additional budget in Story 2
+
+# Robustness & sensitivity
+SPAM_WINDOW_MIN: int = 60
+SPAM_RATE_SPIKE: float = 0.20       # >=20% considered spike
+THRESH_RAISE_FACTOR: float = 1.20   # +20% during spike
+THRESH_DECAY_RATE: float = 0.9      # multiplicative decay per window
+EDGE_WEIGHT_MIN: float = 0.2        # clamp for down-weighting
+
+# Training objectives
+HUBER_DELTA_DEFAULT: float = 1.0
+LABEL_SMOOTH_EPS: float = 0.05
+
+# Limits / guards
+MAX_NODES: int = 1_000_000  # example cap; keep current behaviour if not used
+DEFAULT_TEXT_EMB_POLICY: str = "zeros"  # "zeros" | "mean" | "learned_unknown"
+
+# IO paths (keep existing if already defined elsewhere)
+METRICS_SNAPSHOT_DIR: str = "data/metrics_hourly"
+PREDICTIONS_CACHE_PATH: str = "data/predictions_cache.json"
+
+# Regions
+REGION_DEFAULTS: tuple[str, ...] = ("SG",)
+
+# Timezone policy for bucketing
+BUCKET_TZ: str = "UTC"
+
+# Realtime embedding service guards
+EMBED_MAX_BACKLOG: int = 32
+EMBED_MAX_TOKENS: int = 32

--- a/src/config/schemas.py
+++ b/src/config/schemas.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+from typing import TypedDict, Dict, List
+import numpy as np
+
+
+class Features(TypedDict, total=False):
+    text_emb: np.ndarray  # float32, mean pooled
+    # future: image_emb, lang_id, etc.
+
+
+class Event(TypedDict):
+    event_id: str
+    ts_iso: str              # timezone-aware ISO8601 (UTC)
+    actor_id: str
+    target_ids: List[str]
+    edge_type: str
+    features: Features
+
+
+class StageMs(TypedDict):
+    ingest: int
+    preprocess: int
+    model_update_forward: int
+    postprocess: int
+
+
+class LatencySummary(TypedDict):
+    median_ms: int
+    p95_ms: int
+    per_stage_ms: StageMs
+
+
+class PrecisionAtKSnapshot(TypedDict):
+    k5: float
+    k10: float
+    support: int
+
+
+class HourlyMetrics(TypedDict):
+    precision_at_k: PrecisionAtKSnapshot
+    latency: LatencySummary
+    meta: Dict[str, str]  # {"generated_at": ISO8601}
+
+
+class CacheItem(TypedDict):
+    t_iso: str
+    topk: List[Dict[str, float]]  # {"topic_id": int, "score": float}
+
+
+class PredictionsCache(TypedDict):
+    last_updated: str
+    items: List[CacheItem]

--- a/src/robustness/spam_filter.py
+++ b/src/robustness/spam_filter.py
@@ -1,15 +1,17 @@
-from __future__ import annotations
-
 """Lightweight spam and bot scoring utilities."""
+
+from __future__ import annotations
 
 import math
 import numpy as np
-
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Mapping, Sequence
 
-@dataclass # dataclass allows for easy instantiation and representation
+from config.config import EDGE_WEIGHT_MIN, SPAM_WINDOW_MIN
+
+
+@dataclass  # dataclass allows for easy instantiation and representation
 class SpamScorerConfig:
     """Configuration for :class:`SpamScorer` heuristics."""
 
@@ -24,6 +26,7 @@ class SpamScorerConfig:
         "subscribe",
         # XXX: Add more phrases as needed
     )
+    window_minutes: int = SPAM_WINDOW_MIN
 
 
 class SpamScorer:
@@ -103,7 +106,9 @@ class SpamScorer:
             scores.append(1.0)
 
         # ------------- Blacklist terms ----------------------
-        if texts and any(term in t.lower() for t in texts for term in self.config.blacklist):
+        if texts and any(
+            term in t.lower() for t in texts for term in self.config.blacklist
+        ):
             scores.append(0.0)
         else:
             scores.append(1.0)
@@ -126,4 +131,5 @@ class SpamScorer:
         if user is None:
             return 1.0
 
-        return self.score_account(user)
+        score = self.score_account(user)
+        return max(score, EDGE_WEIGHT_MIN)

--- a/test/test_adaptive_thresholds.py
+++ b/test/test_adaptive_thresholds.py
@@ -1,4 +1,14 @@
-from robustness.adaptive_thresholds import SensitivityController, SensitivityConfig, SLOs
+from robustness.adaptive_thresholds import (
+    SensitivityController,
+    SensitivityConfig,
+    SLOs,
+)
+from config.config import (
+    THRESH_RAISE_FACTOR,
+    THRESH_DECAY_RATE,
+    SLO_MED_MS,
+    SLO_P95_MS,
+)
 
 
 def test_spam_spike_raises_thresholds_and_restores():
@@ -6,9 +16,9 @@ def test_spam_spike_raises_thresholds_and_restores():
         baseline_theta_g=1.0,
         baseline_theta_u=1.0,
         window_size=20,
-        raise_factor=1.2,
+        raise_factor=THRESH_RAISE_FACTOR,
         max_multiplier_of_baseline=2.0,
-        decay_alpha=0.9,
+        decay_alpha=THRESH_DECAY_RATE,
         log_path="data/test_adaptive_thresholds.log",
     )
     ctrl = SensitivityController(config=cfg, slos=SLOs())
@@ -45,7 +55,9 @@ def test_latency_breach_triggers_back_pressure():
         window_size=20,
         log_path="data/test_adaptive_thresholds.log",
     )
-    ctrl = SensitivityController(config=cfg, slos=SLOs(p50_ms=1000, p95_ms=2000))
+    ctrl = SensitivityController(
+        config=cfg, slos=SLOs(p50_ms=SLO_MED_MS, p95_ms=SLO_P95_MS)
+    )
 
     # Fill window with high latency to breach p95
     for _ in range(20):
@@ -55,4 +67,3 @@ def test_latency_breach_triggers_back_pressure():
     assert pol.active is True
     assert pol.heavy_ops_enabled is False
     assert pol.sampler_size >= 2
-

--- a/test/test_event_handler.py
+++ b/test/test_event_handler.py
@@ -1,13 +1,17 @@
+import numpy as np
+
 from embeddings.rt_distilbert import RealtimeTextEmbedder
 from runtime.event_handler import EmbeddingPreprocessor, EventHandler
+from config.schemas import Event
 
 
 def test_preprocessor_adds_embedding():
     embedder = RealtimeTextEmbedder(batch_size=1, max_latency_ms=5, device="cpu")
     pre = EmbeddingPreprocessor(embedder)
-    event = {"text": "hello world"}
+    event: Event = {"text": "hello world"}  # type: ignore[typeddict-item]
     out = pre(event)
     assert "text_emb" in out.setdefault("features", {})
+    assert isinstance(out["features"]["text_emb"], np.ndarray)
     assert len(out["features"]["text_emb"]) == embedder.model.config.hidden_size
 
 


### PR DESCRIPTION
## Summary
- Add unified `src/config` package with shared constants and TypedDict schemas
- Update embedder, runtime handler, and robustness modules to reference new config values and top-level imports
- Refresh tests to import config constants and schemas without `src` prefix

## Testing
- `ruff check src/embeddings/rt_distilbert.py src/robustness/adaptive_thresholds.py src/robustness/spam_filter.py src/runtime/event_handler.py src/main.py test/test_adaptive_thresholds.py test/test_event_handler.py test/test_rt_distilbert.py`  
- `black src/embeddings/rt_distilbert.py src/robustness/adaptive_thresholds.py src/robustness/spam_filter.py src/runtime/event_handler.py src/main.py test/test_adaptive_thresholds.py test/test_event_handler.py test/test_rt_distilbert.py`  
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*  
- `pytest test/test_rt_distilbert.py::test_realtime_embedder_cache_and_latency -q` *(fails: ModuleNotFoundError: No module named 'numpy')*  
- `pytest test/test_event_handler.py::test_preprocessor_adds_embedding -q` *(fails: ModuleNotFoundError: No module named 'numpy')*  
- `pytest test/test_adaptive_thresholds.py::test_spam_spike_raises_thresholds_and_restores -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b832d4ab3c83239e310bf7bf36b73a