### PR TITLE
Add synthetic noise injection for training

### DIFF
--- a/src/config/config.py
+++ b/src/config/config.py
@@ -23,6 +23,11 @@ THRESH_RAISE_FACTOR: float = 1.20   # +20% during spike
 THRESH_DECAY_RATE: float = 0.9      # multiplicative decay per window
 EDGE_WEIGHT_MIN: float = 0.2        # clamp for down-weighting
 
+# Synthetic noise injection
+NOISE_P_DEFAULT: float = 0.08
+NOISE_JITTER_MIN_MIN: int = 3
+NOISE_JITTER_MAX_MIN: int = 10
+
 # Training objectives
 HUBER_DELTA_DEFAULT: float = 1.0
 LABEL_SMOOTH_EPS: float = 0.05

--- a/src/config/schemas.py
+++ b/src/config/schemas.py
@@ -17,6 +17,9 @@ class Event(TypedDict):
     features: Features
 
 
+Batch = List[Event]
+
+
 class StageMs(TypedDict):
     ingest: int
     preprocess: int

--- a/src/model/train.py
+++ b/src/model/train.py
@@ -1,20 +1,52 @@
 import numpy as np
 import os
 import torch
+import logging
+from datetime import datetime
 from model.tgn import TGNModel
+from robustness.noise_injection import inject_noise
+from config.schemas import Batch
+
+logging.basicConfig(level=logging.INFO)
 
 # Load the preprocessed data
-project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')) # abspath to the project root
-data_dir = os.path.join(project_root, 'data/tgn_edges_basic.npz')
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+data_dir = os.path.join(project_root, "data/tgn_edges_basic.npz")
 data = np.load(data_dir, allow_pickle=True)
 
-# Extract data from the npz file
-src = torch.LongTensor(data['src'])
-dst = torch.LongTensor(data['dst'])
-t = torch.FloatTensor(data['t'])
-edge_attr = torch.FloatTensor(data['edge_attr'])
-node_feats = torch.FloatTensor(data['node_features'])
+src_arr = data["src"]
+dst_arr = data["dst"]
+t_arr = data["t"]
+edge_attr_arr = data["edge_attr"]
+node_feats = torch.FloatTensor(data["node_features"])
 num_nodes = node_feats.shape[0]
+EDGE_DIM = edge_attr_arr.shape[1]
+
+events: Batch = []
+for i in range(len(src_arr)):
+    events.append(
+        {
+            "event_id": str(i),
+            "ts_iso": datetime.utcfromtimestamp(float(t_arr[i])).isoformat(),
+            "actor_id": str(src_arr[i]),
+            "target_ids": [str(dst_arr[i])],
+            "edge_type": "edge",
+            "features": {"text_emb": edge_attr_arr[i]},
+        }
+    )
+
+events = inject_noise(events, seed=0)
+
+src = torch.LongTensor([int(e["actor_id"]) for e in events])
+dst = torch.LongTensor([int(e["target_ids"][0]) for e in events])
+t = torch.FloatTensor([datetime.fromisoformat(e["ts_iso"]).timestamp() for e in events])
+edge_attr_list = []
+for e in events:
+    emb = e.get("features", {}).get("text_emb")
+    if emb is None:
+        emb = np.zeros(EDGE_DIM, dtype=np.float32)
+    edge_attr_list.append(emb)
+edge_attr = torch.FloatTensor(edge_attr_list)
 
 # # Build edge stream
 # edge_stream = []

--- a/src/robustness/noise_injection.py
+++ b/src/robustness/noise_injection.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import copy
+import logging
+import random
+from datetime import datetime, timedelta
+from typing import Dict
+
+from config import config
+from config.schemas import Batch, Event
+
+logger = logging.getLogger(__name__)
+
+
+def _jitter_ts(ts_iso: str, rng: random.Random) -> str:
+    jitter_min = config.NOISE_JITTER_MIN_MIN
+    jitter_max = config.NOISE_JITTER_MAX_MIN
+    minutes = rng.uniform(jitter_min, jitter_max)
+    sign = rng.choice([-1, 1])
+    delta = timedelta(minutes=sign * minutes)
+    dt = datetime.fromisoformat(ts_iso)
+    return (dt + delta).isoformat()
+
+
+def inject_noise(batch: Batch, p: float | None = None, seed: int | None = None) -> Batch:
+    """Inject synthetic noise into a batch of events.
+
+    Parameters
+    ----------
+    batch:
+        Sequence of events to corrupt.
+    p:
+        Fraction of events to corrupt. Defaults to ``config.NOISE_P_DEFAULT``.
+    seed:
+        Optional RNG seed for reproducibility.
+    """
+    if p is None:
+        p = config.NOISE_P_DEFAULT
+    if not batch or p <= 0:
+        return batch
+
+    rng = random.Random(seed)
+    n = len(batch)
+    k = max(1, int(p * n))
+    indices = rng.sample(range(n), k)
+
+    new_batch = list(batch)
+    counts: Dict[str, int] = {"missing": 0, "duplicate": 0, "jitter": 0, "bot_burst": 0}
+
+    for idx in indices:
+        event = copy.deepcopy(new_batch[idx])
+        mode = rng.choice(list(counts.keys()))
+        if mode == "missing":
+            event.get("features", {}).pop("text_emb", None)
+            new_batch[idx] = event
+            counts[mode] += 1
+        elif mode == "duplicate":
+            new_batch.append(event)
+            counts[mode] += 1
+        elif mode == "jitter":
+            event["ts_iso"] = _jitter_ts(event["ts_iso"], rng)
+            new_batch[idx] = event
+            counts[mode] += 1
+        elif mode == "bot_burst":
+            burst = rng.randint(2, 4)
+            for _ in range(burst):
+                dup = copy.deepcopy(event)
+                dup["ts_iso"] = _jitter_ts(event["ts_iso"], rng)
+                new_batch.append(dup)
+                counts[mode] += 1
+
+    logger.info("noise injection counts: %s", counts)
+    return new_batch


### PR DESCRIPTION
## Summary
- add configurable synthetic noise defaults
- implement noise injection helper and call from training loop
- wire up batch schema alias

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python src/model/train.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b850192cb08323ab5909274f74f12c