### PR TITLE
feat: expose multi-metric trend outputs

### DIFF
--- a/src/model/core/tgn.py
+++ b/src/model/core/tgn.py
@@ -25,8 +25,14 @@ class TGNModel(nn.Module):
             aggregator_module=self.aggregator_module,
         )
 
+        # Decoder now produces three values per edge interaction:
+        #   1. emergence probability
+        #   2. growth rate
+        #   3. diffusion score
         self.decoder = nn.Sequential(
-            nn.Linear(memory_dim * 2 + time_dim, 100), nn.ReLU(), nn.Linear(100, 1)
+            nn.Linear(memory_dim * 2 + time_dim, 100),
+            nn.ReLU(),
+            nn.Linear(100, 3),
         )
 
     def forward(self, src, dst, t, edge_attr):

--- a/src/model/training/train.py
+++ b/src/model/training/train.py
@@ -88,15 +88,16 @@ for epoch in range(3):  # TODO: 3 epochs for quick testing; increase for actual 
         dst_i = dst[i].unsqueeze(0).long()
         t_i = t[i].unsqueeze(0)
         edge_feat = edge_attr[i].unsqueeze(0)
-        label = torch.tensor([1.0])  # Dummy
+        label = torch.tensor([1.0])  # Dummy emergence label
 
         # DEBUG
         if i == 0:
             print(src_i.dtype, t_i.dtype, edge_feat.dtype)
 
         # forward / loss / optimize
-        out = model(src_i, dst_i, t_i, edge_feat)
-        loss = criterion(out.view(-1), label)
+        out = model(src_i, dst_i, t_i, edge_feat).view(-1)
+        # Train only on emergence probability for this example
+        loss = criterion(out[0:1], label)
         optimizer.zero_grad()
         loss.backward()
         optimizer.step()

--- a/src/service/services/inference/tgn_service.py
+++ b/src/service/services/inference/tgn_service.py
@@ -2,7 +2,8 @@
 
 Wraps a trained Temporal Graph Network (TGN) for online inference in an
 event-driven pipeline. Each event updates the temporal memory and triggers a
-forward pass that yields per-topic trend emergence scores in [0, 1].
+forward pass that yields three trend metrics: emergence probability, growth
+rate, and diffusion score.
 
 Key features:
 - LRU-based soft memory limiting via MAX_NODES.
@@ -254,7 +255,7 @@ class TGNInferenceService:
 
     # ------------------------------------------------------------------
     def update_and_score(self, event: Event) -> Dict[str, float]:
-        """Update the TGN with the event and return per-topic scores.
+        """Update the TGN with the event and return trend metrics.
 
         The service processes only the first target in ``target_ids`` for the
         forward pass to preserve latency; additional targets can be handled by
@@ -265,8 +266,8 @@ class TGNInferenceService:
                 target_ids, edge_type, features}.
 
         Returns:
-            Mapping of topic identifier to score in [0, 1]. Currently a
-            single-topic output is provided under key "topic:0".
+            Mapping with three entries: ``emergence_probability`` in [0, 1],
+            raw ``growth_rate`` (unbounded), and ``diffusion_score`` in [0, 1].
         """
         actor_id = str(event.get("actor_id", "0"))
         targets = event.get("target_ids") or []
@@ -299,12 +300,19 @@ class TGNInferenceService:
         # Forward pass
         fwd_start = time.perf_counter()
         logits = self.model(src_tensor, dst_tensor, t_tensor, e_attr)
-        probs = torch.sigmoid(logits).view(-1)
+        logits = logits.view(-1)
         forward_ms = (time.perf_counter() - fwd_start) * 1000.0
 
         # Log latencies (append-only, non-blocking)
         self._log_latencies(update_ms, forward_ms)
 
-        # Produce per-topic score dictionary (single topic for now)
-        score = float(probs[0].clamp(0.0, 1.0).item())
-        return {"topic:0": score}
+        # Split decoder outputs into named metrics
+        emergence = torch.sigmoid(logits[0]).clamp(0.0, 1.0).item()
+        growth = logits[1].item()
+        diffusion = torch.sigmoid(logits[2]).clamp(0.0, 1.0).item()
+
+        return {
+            "emergence_probability": float(emergence),
+            "growth_rate": float(growth),
+            "diffusion_score": float(diffusion),
+        }


### PR DESCRIPTION
## Summary
- extend TGN decoder to return emergence probability, growth rate and diffusion score
- adapt inference service to unpack multi-dimensional outputs
- adjust training example for new decoder signature

## Testing
- `pytest -q` *(fails: No module named 'torch', 'streamlit', and missing internal modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bc253cd0f0832399ade45ff0371e90