### PR TITLE
Add rolling adaptivity metric and expose in runtime snapshots

### DIFF
--- a/src/config/schemas.py
+++ b/src/config/schemas.py
@@ -42,6 +42,7 @@ class PrecisionAtKSnapshot(TypedDict):
 
 class HourlyMetrics(TypedDict):
     precision_at_k: PrecisionAtKSnapshot
+    adaptivity: float
     latency: LatencySummary
     meta: Dict[str, str]  # {"generated_at": ISO8601}
 

--- a/src/service/runtime_glue.py
+++ b/src/service/runtime_glue.py
@@ -125,13 +125,15 @@ class RuntimeGlue:
     def _update_metrics_and_cache(self):
         """Update rolling P@K, write hourly snapshots, and update predictions cache."""
         now = datetime.now(timezone.utc)
-        
+
         # Get rolling precision scores
         precision_snapshot = self.precision_tracker.rolling_hourly_scores()
+        adaptivity_score = self.precision_tracker.rolling_adaptivity_score()
         
         # Create hourly metrics (simplified - in real impl would include latency data)
         hourly_metrics = HourlyMetrics(
             precision_at_k=precision_snapshot,
+            adaptivity=adaptivity_score,
             latency={
                 'median_ms': 0,  # Would be populated from LatencyAggregator
                 'p95_ms': 0,

--- a/tests/integration/example_service_integration.py
+++ b/tests/integration/example_service_integration.py
@@ -92,6 +92,7 @@ class TrendPredictionService:
         
         hourly_metrics = HourlyMetrics(
             precision_at_k=precision_snapshot,
+            adaptivity=0.0,
             latency=latency_summary,
             meta={"service": "trend_prediction"}
         )

--- a/tests/unit/test_latency_system.py
+++ b/tests/unit/test_latency_system.py
@@ -113,6 +113,7 @@ def test_metrics_writer():
     # Create test metrics payload
     test_metrics = HourlyMetrics(
         precision_at_k=PrecisionAtKSnapshot(k5=0.85, k10=0.75, support=100),
+        adaptivity=0.0,
         latency={
             'median_ms': 800,
             'p95_ms': 1200,
@@ -207,6 +208,7 @@ def test_end_to_end():
     
     hourly_metrics = HourlyMetrics(
         precision_at_k=PrecisionAtKSnapshot(k5=0.9, k10=0.8, support=50),
+        adaptivity=0.0,
         latency=latency_summary,
         meta={"source": "end_to_end_test"}
     )

--- a/tests/unit/test_runtime_glue.py
+++ b/tests/unit/test_runtime_glue.py
@@ -163,8 +163,9 @@ def test_runtime_glue_updates_metrics():
         # Verify metrics file content
         with open(metrics_files[0], 'r') as f:
             metrics_data = json.load(f)
-        
+
         assert 'precision_at_k' in metrics_data
+        assert 'adaptivity' in metrics_data
         assert 'latency' in metrics_data
         assert 'meta' in metrics_data
         assert metrics_data['meta']['service'] == 'runtime_glue'


### PR DESCRIPTION
## Summary
- track MAPE-based adaptivity decay in `PrecisionAtKOnline`
- include rolling adaptivity score in RuntimeGlue hourly metrics
- extend HourlyMetrics schema and tests for new metric

## Testing
- `PYTHONPATH=. pytest tests/unit/test_runtime_glue.py::test_runtime_glue_updates_metrics -q`
- `PYTHONPATH=. pytest tests/unit/test_latency_system.py::test_metrics_writer -q`
- ⚠️ `pytest -q` *(missing torch/streamlit dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bc2551bf74832399b567bab836572c