### PR TITLE
Add drift monitor and retraining utilities

### DIFF
--- a/src/model/inference/__init__.py
+++ b/src/model/inference/__init__.py
@@ -2,5 +2,10 @@
 
 from .spam_filter import SpamScorer
 from .adaptive_thresholds import SensitivityController
+from .drift_monitor import PerformanceDriftMonitor
 
-__all__ = ["SpamScorer", "SensitivityController"]
+__all__ = [
+    "SpamScorer",
+    "SensitivityController",
+    "PerformanceDriftMonitor",
+]

--- a/src/model/inference/drift_monitor.py
+++ b/src/model/inference/drift_monitor.py
@@ -1,0 +1,105 @@
+"""Performance drift monitoring utilities.
+
+This module provides :class:`PerformanceDriftMonitor` which tracks rolling
+F1 and Precision@K metrics for model predictions.  An alert callback is
+invoked whenever the rolling averages fall below configured thresholds.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Callable, Deque, Iterable, Sequence
+
+
+class PerformanceDriftMonitor:
+    """Monitor rolling F1 and Precision@K values.
+
+    The monitor stores the most recent ``window`` metric values and computes
+    rolling averages.  When either average drops below the configured
+    thresholds, the ``alert_fn`` is called with a descriptive message.
+    """
+
+    def __init__(
+        self,
+        *,
+        window: int = 100,
+        f1_threshold: float = 0.7,
+        precision_k_threshold: float = 0.7,
+        k: int = 5,
+        alert_fn: Callable[[str], None] | None = None,
+    ) -> None:
+        self.window = int(window)
+        self.f1_threshold = float(f1_threshold)
+        self.precision_k_threshold = float(precision_k_threshold)
+        self.k = int(k)
+        self.alert_fn = alert_fn or (lambda msg: print(msg))
+
+        self._f1_scores: Deque[float] = deque(maxlen=self.window)
+        self._p_at_k_scores: Deque[float] = deque(maxlen=self.window)
+
+    # ------------------------------------------------------------------
+    def update(
+        self,
+        y_true: Sequence[int],
+        y_pred: Sequence[int],
+        *,
+        topk_pred: Sequence[int],
+        relevant_items: Iterable[int],
+    ) -> None:
+        """Update metric buffers and check for drift.
+
+        Args:
+            y_true: Ground-truth binary labels.
+            y_pred: Predicted binary labels.
+            topk_pred: Ordered item ids ranked by predicted score.
+            relevant_items: Iterable of item ids considered relevant for
+                computing Precision@K.
+        """
+        f1 = self._f1_score(y_true, y_pred)
+        p_at_k = self._precision_at_k(topk_pred, relevant_items)
+        self._f1_scores.append(f1)
+        self._p_at_k_scores.append(p_at_k)
+        self._check_alerts()
+
+    # ------------------------------------------------------------------
+    def _check_alerts(self) -> None:
+        if self._f1_scores:
+            avg_f1 = sum(self._f1_scores) / len(self._f1_scores)
+            if avg_f1 < self.f1_threshold:
+                self.alert_fn(
+                    f"Rolling F1 dropped to {avg_f1:.3f} (< {self.f1_threshold:.3f})"
+                )
+        if self._p_at_k_scores:
+            avg_p = sum(self._p_at_k_scores) / len(self._p_at_k_scores)
+            if avg_p < self.precision_k_threshold:
+                self.alert_fn(
+                    f"Rolling Precision@{self.k} dropped to {avg_p:.3f} (< {self.precision_k_threshold:.3f})"
+                )
+
+    # ------------------------------------------------------------------
+    def _f1_score(self, y_true: Sequence[int], y_pred: Sequence[int]) -> float:
+        tp = fp = fn = 0
+        for yt, yp in zip(y_true, y_pred):
+            if yt == 1 and yp == 1:
+                tp += 1
+            elif yt == 0 and yp == 1:
+                fp += 1
+            elif yt == 1 and yp == 0:
+                fn += 1
+        precision = tp / (tp + fp) if tp + fp else 0.0
+        recall = tp / (tp + fn) if tp + fn else 0.0
+        return 0.0 if precision + recall == 0 else 2 * precision * recall / (precision + recall)
+
+    # ------------------------------------------------------------------
+    def _precision_at_k(
+        self, predictions: Sequence[int], relevant_items: Iterable[int]
+    ) -> float:
+        k = min(self.k, len(predictions))
+        if k == 0:
+            return 0.0
+        rel_set = set(relevant_items)
+        hits = 0
+        for item in list(predictions)[:k]:
+            if item in rel_set:
+                hits += 1
+        return hits / float(k)

--- a/src/model/training/retrain.py
+++ b/src/model/training/retrain.py
@@ -1,0 +1,105 @@
+"""Retraining utilities with canary deployment and rollback.
+
+This module offers a high level :func:`retrain_and_deploy` helper that wraps
+model training, canary deployment, and automatic rollback.  It relies on
+callables passed in by the caller so it can be integrated with different
+training frameworks.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from pathlib import Path
+from typing import Callable
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+def retrain_and_deploy(
+    train_fn: Callable[[], Path],
+    evaluate_fn: Callable[[Path], float],
+    *,
+    prod_model_path: str,
+    canary_dir: str,
+    metric_threshold: float = 0.8,
+) -> Path:
+    """Retrain the model and roll out via a canary deployment.
+
+    Args:
+        train_fn: Callable that trains a model and returns the path to the
+            saved artifact.
+        evaluate_fn: Callable that evaluates a model and returns a scalar
+            performance metric where higher is better.
+        prod_model_path: Destination path for the production model.
+        canary_dir: Directory where the canary model will be staged.
+        metric_threshold: Minimum acceptable evaluation metric for promotion.
+
+    Returns:
+        Path to the model that ended up serving production traffic.  If the
+        canary evaluation fails, the previous production model path is
+        returned after rollback.
+    """
+
+    prod_path = Path(prod_model_path)
+    canary_dir_path = Path(canary_dir)
+    canary_dir_path.mkdir(parents=True, exist_ok=True)
+
+    LOGGER.info("Starting retraining...")
+    new_model = train_fn()
+    LOGGER.info("Training complete: %s", new_model)
+
+    canary_path = canary_dir_path / new_model.name
+    shutil.copy2(new_model, canary_path)
+    LOGGER.info("Canary model staged at %s", canary_path)
+
+    score = evaluate_fn(canary_path)
+    LOGGER.info("Canary evaluation score: %.4f", score)
+
+    backup_path = None
+    if prod_path.exists():
+        backup_path = prod_path.with_suffix(prod_path.suffix + ".bak")
+        shutil.copy2(prod_path, backup_path)
+        LOGGER.info("Backed up existing production model to %s", backup_path)
+
+    if score >= metric_threshold:
+        shutil.copy2(canary_path, prod_path)
+        LOGGER.info("Promoted canary to production: %s", prod_path)
+        if backup_path and backup_path.exists():
+            backup_path.unlink()
+        return prod_path
+
+    LOGGER.warning(
+        "Canary score %.4f below threshold %.4f; rolling back", score, metric_threshold
+    )
+    if backup_path and backup_path.exists():
+        shutil.copy2(backup_path, prod_path)
+        backup_path.unlink()
+        LOGGER.info("Restored previous production model from backup")
+    return prod_path
+
+
+if __name__ == "__main__":
+    import argparse
+    import importlib
+
+    parser = argparse.ArgumentParser(description="Retrain model with canary deployment")
+    parser.add_argument("train", help="Dotted path to training function returning model Path")
+    parser.add_argument("evaluate", help="Dotted path to evaluation function")
+    parser.add_argument("prod_model_path", help="Path to production model file")
+    parser.add_argument("canary_dir", help="Directory for canary deployment")
+    parser.add_argument("--threshold", type=float, default=0.8, help="Metric threshold for promotion")
+    args = parser.parse_args()
+
+    def _load_callable(dotted: str) -> Callable:
+        module, name = dotted.rsplit(".", 1)
+        return getattr(importlib.import_module(module), name)
+
+    retrain_and_deploy(
+        _load_callable(args.train),
+        _load_callable(args.evaluate),
+        prod_model_path=args.prod_model_path,
+        canary_dir=args.canary_dir,
+        metric_threshold=args.threshold,
+    )

--- a/tests/unit/test_drift_monitor.py
+++ b/tests/unit/test_drift_monitor.py
@@ -1,0 +1,33 @@
+import pytest
+
+from model.inference.drift_monitor import PerformanceDriftMonitor
+
+
+def test_drift_monitor_alerts_on_drop():
+    alerts: list[str] = []
+    monitor = PerformanceDriftMonitor(
+        window=2,
+        f1_threshold=0.75,
+        precision_k_threshold=0.5,
+        k=2,
+        alert_fn=alerts.append,
+    )
+
+    # Initial high-performance update
+    monitor.update(
+        y_true=[1, 0, 1],
+        y_pred=[1, 0, 1],
+        topk_pred=[1, 2],
+        relevant_items=[1],
+    )
+    assert alerts == []  # no alert yet
+
+    # Second update with poor performance should trigger alerts
+    monitor.update(
+        y_true=[1, 1, 1],
+        y_pred=[0, 0, 0],
+        topk_pred=[3, 4],
+        relevant_items=[5],
+    )
+    assert any("F1" in msg for msg in alerts)
+    assert any("Precision@2" in msg for msg in alerts)


### PR DESCRIPTION
## Summary
- monitor rolling F1/Precision@K and alert on drops
- add retraining helper with canary deployment and rollback
- cover monitor behaviour with unit tests

## Testing
- `python -m pytest tests/unit/test_drift_monitor.py`
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==2.1.0+cpu torchvision==0.16.0+cpu -f https://download.pytorch.org/whl/torch_stable.html` *(fails: Could not find a version that satisfies the requirement torch==2.1.0+cpu)*
- `pip install streamlit` *(fails: Could not find a version that satisfies the requirement streamlit)*

------
https://chatgpt.com/codex/tasks/task_e_68bc255850308323a2b7c0b4ff0a8333