### PR TITLE
Use absolute slugify imports in data pipeline

### DIFF
--- a/src/data_pipeline/collectors/google_trends_collector.py
+++ b/src/data_pipeline/collectors/google_trends_collector.py
@@ -6,7 +6,7 @@ try:
 except Exception:  # ImportError or other errors
     TrendReq = None
 
-from ...utils.text import slugify as _slugify
+from utils.text import slugify as _slugify
 
 
 def start_google_trends_collector(

--- a/src/data_pipeline/transformers/event_parser.py
+++ b/src/data_pipeline/transformers/event_parser.py
@@ -1,4 +1,4 @@
-from ...utils.text import slugify as _slugify
+from utils.text import slugify as _slugify
 
 
 def parse_event(event):


### PR DESCRIPTION
## Summary
- import slugify via absolute `utils.text` in Google Trends collector and event parser

## Testing
- `pip install -e . --no-deps --no-build-isolation`
- `pytest -q` *(fails: No module named 'torch')*
- `python -m service.main` *(fails: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bc515510108323a83554428875d2a6