### PR TITLE
Use timezone-aware datetime in spam filter

### DIFF
--- a/src/model/inference/spam_filter.py
+++ b/src/model/inference/spam_filter.py
@@ -3,10 +3,11 @@
 import math
 import numpy as np
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Mapping, Sequence
 
 from config.config import EDGE_WEIGHT_MIN, SPAM_WINDOW_MIN
+from utils.datetime import parse_iso_timestamp
 
 
 @dataclass  # dataclass allows for easy instantiation and representation
@@ -49,14 +50,14 @@ class SpamScorer:
         gracefully when data is sparse.
         """
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         scores: list[float] = []
 
         # -------------- Account age -------------------
         created = user.get("created_at")
         age_days = 0.0
         if isinstance(created, str):
-            created_dt = datetime.fromisoformat(created)
+            created_dt = parse_iso_timestamp(created)
             age_days = (now - created_dt).total_seconds() / 86400.0
         scores.append(min(1.0, age_days / self.config.min_account_age_days))
 


### PR DESCRIPTION
## Summary
- ensure spam scoring uses timezone-aware timestamps
- parse `created_at` with shared ISO parser

## Testing
- `pytest tests/unit/test_spam_filter.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest tests/unit/test_latency_panel.py -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*


------
https://chatgpt.com/codex/tasks/task_e_68bc591f22648323ba8c39731a269446