### PR TITLE
Use timezone-aware UTC datetime

### DIFF
--- a/src/data_pipeline/collectors/google_trends_collector.py
+++ b/src/data_pipeline/collectors/google_trends_collector.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 # Try to import the pytrends library
 try:
@@ -58,7 +58,7 @@ def start_google_trends_collector(
                         if title:
                             contexts.append(title)
                 event = {
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                     "content_id": f"trend_{_slugify(term)}",
                     "source": "google_trends",
                     "type": "trend",
@@ -80,7 +80,7 @@ def fake_google_trends_stream(on_event=None, n_events: int = 5, delay: float = 1
     for i in range(n_events):
         term = f"Example Trend {i}"
         event = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "content_id": f"trend_{_slugify(term)}",
             "source": "google_trends",
             "type": "trend",

--- a/src/model/evaluation/metrics.py
+++ b/src/model/evaluation/metrics.py
@@ -11,7 +11,7 @@ label freeze and a rolling hourly snapshot window.
 """
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Deque, Dict, Iterator, Optional, Tuple, Iterable, List
 from collections import deque
 import json
@@ -293,7 +293,7 @@ class PrecisionAtKOnline:
 
     # ------------------------------------------------------------------
     def rolling_hourly_scores(self) -> PrecisionAtKSnapshot:
-        now = self._latest_ts or datetime.utcnow()
+        now = self._latest_ts or datetime.now(timezone.utc)
         window_start = now - timedelta(minutes=self.window_min)
         matured: List[_TopKEntry] = []
         for entry in self._pred_log:
@@ -382,7 +382,9 @@ class PrecisionAtKOnline:
             The full path written to on success; None on best-effort failure.
         """
         record = {
-            "ts": (self._latest_ts or datetime.utcnow()).isoformat(timespec="seconds"),
+            "ts": (self._latest_ts or datetime.now(timezone.utc)).isoformat(
+                timespec="seconds"
+            ),
             "precision_at_k": self.rolling_hourly_scores(),
             "adaptivity": self.rolling_adaptivity_score(),
         }

--- a/src/model/inference/adaptive_thresholds.py
+++ b/src/model/inference/adaptive_thresholds.py
@@ -1,7 +1,7 @@
 """Adaptive sensitivity and back-pressure controller."""
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from threading import RLock
 from typing import Deque, Dict, Iterable, Optional
 from collections import deque
@@ -252,7 +252,7 @@ class SensitivityController:
         return target + (value - target) * (1.0 - alpha)
 
     def _maybe_apply_back_pressure(self) -> None:
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         p95 = self._p95_ms()
 
         if p95 > self.slos.p95_ms:
@@ -311,7 +311,7 @@ class SensitivityController:
 
     def _log(self, *, action: str, payload: Dict[str, object]) -> None:
         record = {
-            "ts": datetime.utcnow().isoformat(timespec="milliseconds"),
+            "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
             "action": action,
             **payload,
         }

--- a/src/model/inference/spam_filter.py
+++ b/src/model/inference/spam_filter.py
@@ -3,8 +3,10 @@
 import math
 import numpy as np
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Mapping, Sequence
+
+from utils.datetime import parse_iso_timestamp
 
 from config.config import EDGE_WEIGHT_MIN, SPAM_WINDOW_MIN
 
@@ -49,14 +51,14 @@ class SpamScorer:
         gracefully when data is sparse.
         """
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         scores: list[float] = []
 
         # -------------- Account age -------------------
         created = user.get("created_at")
         age_days = 0.0
         if isinstance(created, str):
-            created_dt = datetime.fromisoformat(created)
+            created_dt = parse_iso_timestamp(created)
             age_days = (now - created_dt).total_seconds() / 86400.0
         scores.append(min(1.0, age_days / self.config.min_account_age_days))
 
@@ -70,7 +72,7 @@ class SpamScorer:
         posts = list(user.get("posts", []))
         if len(posts) > 1:
             times = sorted(
-                datetime.fromisoformat(p["timestamp"]).timestamp()
+                parse_iso_timestamp(p["timestamp"]).timestamp()
                 for p in posts
                 if "timestamp" in p
             )

--- a/tests/unit/test_spam_filter.py
+++ b/tests/unit/test_spam_filter.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from model.inference.spam_filter import SpamScorer
 from data_pipeline.storage.builder import GraphBuilder
@@ -7,7 +7,7 @@ from data_pipeline.processors.text_rt_distilbert import RealtimeTextEmbedder
 
 
 def _spam_user():
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     return {
         "created_at": (now - timedelta(days=1)).isoformat(),
         "followers": 5,
@@ -29,7 +29,7 @@ def test_spam_scorer_flags_spam_accounts():
 def test_graph_builder_downweights_spam_edges():
     scorer = SpamScorer()
     user = _spam_user()
-    ts = datetime.utcnow()
+    ts = datetime.now(timezone.utc)
     builder = GraphBuilder(reference_time=ts, spam_scorer=scorer)
     event = {
         "timestamp": ts.isoformat(),


### PR DESCRIPTION
## Summary
- Replace `datetime.utcnow()` with `datetime.now(timezone.utc)` across modules
- Normalize timestamp parsing to handle timezone-aware values via `parse_iso_timestamp`
- Update spam filter tests to use timezone-aware timestamps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68bc597ea0f08323af022ef238399520