### PR TITLE
Use timezone-aware timestamps in collectors

### DIFF
--- a/src/data_pipeline/collectors/google_trends_collector.py
+++ b/src/data_pipeline/collectors/google_trends_collector.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 # Try to import the pytrends library
 try:
@@ -58,7 +58,7 @@ def start_google_trends_collector(
                         if title:
                             contexts.append(title)
                 event = {
-                    "timestamp": datetime.utcnow().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                     "content_id": f"trend_{_slugify(term)}",
                     "source": "google_trends",
                     "type": "trend",
@@ -80,7 +80,7 @@ def fake_google_trends_stream(on_event=None, n_events: int = 5, delay: float = 1
     for i in range(n_events):
         term = f"Example Trend {i}"
         event = {
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "content_id": f"trend_{_slugify(term)}",
             "source": "google_trends",
             "type": "trend",

--- a/src/data_pipeline/collectors/youtube_collector.py
+++ b/src/data_pipeline/collectors/youtube_collector.py
@@ -1,5 +1,5 @@
 from googleapiclient.discovery import build
-from datetime import datetime
+from datetime import datetime, timezone
 import time
 
 
@@ -49,7 +49,7 @@ def start_youtube_api_collector(
                 tags = item["snippet"].get("tags", [])
                 hashtags = [t for t in tags if t.startswith("#")]
                 event = {
-                    "timestamp": datetime.now().isoformat(),
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
                     "user_id": f"yt_u_{channel_title.replace(' ', '_')}",
                     "content_id": f"yt_v_{video_id}",
                     "hashtags": hashtags,


### PR DESCRIPTION
## Summary
- Emit UTC ISO timestamps in YouTube collector events
- Generate timezone-aware timestamps for Google Trends collector and fake stream

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bc59911914832391cebcefb5dd7ad8