### PR TITLE
Fix dashboard latency import and path setup

### DIFF
--- a/dashboard/__init__.py
+++ b/dashboard/__init__.py
@@ -1,0 +1,2 @@
+"""Dashboard package for Trend Prediction application."""
+

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -15,6 +15,8 @@ sys.path.insert(0, str(src_path))
 # Add current directory to path for local imports
 dashboard_path = Path(__file__).parent
 sys.path.insert(0, str(dashboard_path))
+# Add repository root to path so `dashboard.*` imports work
+sys.path.insert(0, str(dashboard_path.parent))
 
 from components import topk
 

--- a/dashboard/components/latency.py
+++ b/dashboard/components/latency.py
@@ -21,11 +21,11 @@ sys.path.insert(0, str(src_path))
 
 from config.config import SLO_MED_MS, SLO_P95_MS, METRICS_SNAPSHOT_DIR
 from config.schemas import HourlyMetrics, LatencySummary, StageMs
-from dashboard.layouts.layout import (
-    render_metric_card, 
-    render_stage_table, 
+from layouts.layout import (
+    render_metric_card,
+    render_stage_table,
     render_breach_indicator,
-    apply_custom_css
+    apply_custom_css,
 )
 
 
@@ -342,5 +342,5 @@ def render_panel(
         "latest_median_ms": latest_latency['median_ms'],
         "latest_p95_ms": latest_latency['p95_ms'],
         "median_slo_met": not median_breach,
-        "p95_slo_met": not p95_breach
+        "p95_slo_met": not p95_breach,
     }


### PR DESCRIPTION
## Summary
- Use local layouts import in latency component
- Insert repo root into sys.path and add dashboard package marker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch'; No module named 'streamlit')*
- `streamlit run dashboard/app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a97b7f08323a23d2531dedc9756