### PR TITLE
Refactor path handling to centralize repository root resolution

### DIFF
--- a/src/config/base.py
+++ b/src/config/base.py
@@ -1,10 +1,11 @@
 """Base configuration settings."""
 
-import os
 from pathlib import Path
 
+from utils.path_utils import find_repo_root
+
 # Base directory configuration
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+PROJECT_ROOT = find_repo_root()
 DATA_DIR = PROJECT_ROOT / "datasets"
 LOGS_DIR = PROJECT_ROOT / "logs"
 

--- a/src/model/inference/adaptive_thresholds.py
+++ b/src/model/inference/adaptive_thresholds.py
@@ -6,7 +6,9 @@ from threading import RLock
 from typing import Deque, Dict, Iterable, Optional
 from collections import deque
 import json
-import os
+from pathlib import Path
+
+from utils.path_utils import find_repo_root
 
 from config.config import (
     SPAM_RATE_SPIKE,
@@ -51,7 +53,7 @@ class SensitivityConfig:
     raise_factor: float = THRESH_RAISE_FACTOR
     max_multiplier_of_baseline: float = 2.0
     decay_alpha: float = THRESH_DECAY_RATE
-    log_path: str = os.path.join("datasets", "adaptive_thresholds.log")
+    log_path: Path = find_repo_root() / "datasets" / "adaptive_thresholds.log"
     window_minutes: int = SPAM_WINDOW_MIN
 
 
@@ -102,6 +104,7 @@ class SensitivityController:
         max_sampler_size: int = 64,
     ) -> None:
         self.cfg = config or SensitivityConfig()
+        self.cfg.log_path = Path(self.cfg.log_path)
         self.slos = slos or SLOs()
 
         # Sliding windows
@@ -123,7 +126,7 @@ class SensitivityController:
         self._cooldown_until: Optional[datetime] = None
 
         # Logging
-        os.makedirs(os.path.dirname(self.cfg.log_path), exist_ok=True)
+        self.cfg.log_path.parent.mkdir(parents=True, exist_ok=True)
 
         self._lock = RLock()
 
@@ -321,3 +324,4 @@ class SensitivityController:
         except Exception:
             # Best-effort logging; never raise from controller
             pass
+

--- a/src/model/training/train.py
+++ b/src/model/training/train.py
@@ -1,4 +1,3 @@
-import os
 import logging
 from datetime import datetime
 import numpy as np
@@ -9,6 +8,7 @@ from model.core.tgn import TGNModel
 from model.training.noise_injection import inject_noise
 from config.schemas import Batch
 from config.config import LABEL_SMOOTH_EPS
+from utils.path_utils import find_repo_root
 
 logging.basicConfig(level=logging.INFO)
 
@@ -56,8 +56,8 @@ def smoothed_cross_entropy(
 
 if __name__ == "__main__":
     # Example training loop demonstrating usage of smoothed cross-entropy.
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    data_dir = os.path.join(project_root, "datasets/tgn_edges_basic.npz")
+    repo_root = find_repo_root()
+    data_dir = repo_root / "datasets" / "tgn_edges_basic.npz"
     data = np.load(data_dir, allow_pickle=True)
 
     src_arr = data["src"]

--- a/src/model/training/train_growth.py
+++ b/src/model/training/train_growth.py
@@ -12,6 +12,7 @@ import torch
 from config.config import HUBER_DELTA_DEFAULT
 from model.core.losses import HuberLoss, log_huber_vs_mse_curve
 from utils.io import maybe_load_yaml
+from utils.path_utils import find_repo_root
 
 
 def train_growth(yaml_path: Optional[str] = None) -> None:
@@ -47,7 +48,7 @@ def train_growth(yaml_path: Optional[str] = None) -> None:
         optim.step()
 
     # Log Huber vs MSE curve for ablations
-    out_path = os.path.join("datasets", "huber_vs_mse.csv")
+    out_path = find_repo_root() / "datasets" / "huber_vs_mse.csv"
     log_huber_vs_mse_curve(
         path=out_path, delta=delta if delta is not None else HUBER_DELTA_DEFAULT
     )

--- a/src/model/training/tune.py
+++ b/src/model/training/tune.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
-import os
+from pathlib import Path
 from datetime import datetime
 from typing import Any, Generator, Iterable, Tuple
 
@@ -25,6 +25,7 @@ except Exception:  # pragma: no cover - keep import-time errors lazily
     optuna = None  # type: ignore
 
 from model.core.tgn import TGNModel
+from utils.path_utils import find_repo_root
 
 
 logger = logging.getLogger(__name__)
@@ -38,9 +39,9 @@ def _load_data() -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.nda
     deterministic synthetic one when the expected ``.npz`` file is absent.
     """
 
-    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-    data_path = os.path.join(project_root, "datasets", "tgn_edges_basic.npz")
-    if os.path.exists(data_path):
+    repo_root = find_repo_root()
+    data_path = repo_root / "datasets" / "tgn_edges_basic.npz"
+    if data_path.exists():
         data = np.load(data_path, allow_pickle=True)
         return (
             data["src"],
@@ -174,8 +175,8 @@ def tune_hyperparameters(n_trials: int = 20) -> Any:
     study.optimize(objective, n_trials=n_trials)
     logger.info("Best params: %s", study.best_params)
 
-    log_path = os.path.join(os.path.dirname(__file__), "tuning_log.json")
-    with open(log_path, "w", encoding="utf-8") as f:
+    log_path = Path(__file__).resolve().parent / "tuning_log.json"
+    with log_path.open("w", encoding="utf-8") as f:
         json.dump({"best_params": study.best_params, "best_value": study.best_value}, f, indent=2)
 
     return study

--- a/src/service/main.py
+++ b/src/service/main.py
@@ -1,5 +1,4 @@
-"""Unified main entry point for streaming trend prediction service.
-"""
+"""Unified main entry point for streaming trend prediction service."""
 
 import os
 import sys
@@ -12,15 +11,15 @@ from typing import Dict, Any, Callable, Sequence, Iterable, Generator, Tuple
 
 import numpy as np
 
+from utils.path_utils import find_repo_root
+
 # Load environment variables from .env file
+project_root = find_repo_root()
 try:
     from dotenv import load_dotenv
-    # Load .env file from project root
-    project_root = Path(__file__).resolve().parents[2]
     load_dotenv(project_root / ".env")
 except ImportError:
     print("Warning: python-dotenv not installed. Please install it with: pip install python-dotenv")
-    project_root = Path(__file__).resolve().parents[2]
 
 # Ensure we can import from src
 src_path = project_root / "src"

--- a/src/utils/path_utils.py
+++ b/src/utils/path_utils.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+
+def find_repo_root(start: Path | None = None, marker: str = "pyproject.toml") -> Path:
+    """Walk upwards from ``start`` until a folder containing ``marker`` is found.
+
+    Args:
+        start: Optional starting path. Defaults to the location of this file.
+        marker: Filename used to identify the repository root.
+
+    Returns:
+        The repository root as a :class:`Path`.
+    """
+    p = (start or Path(__file__).resolve()).parent
+    for candidate in [p, *p.parents]:
+        if (candidate / marker).exists():
+            return candidate
+    return p  # fallback if marker not found

--- a/tests/integration/run_ingestion_sim.py
+++ b/tests/integration/run_ingestion_sim.py
@@ -5,7 +5,6 @@ Runs the fake Twitter stream and a short fake Google Trends burst, routes events
 through the EventHandler/GraphBuilder, then saves a TemporalData checkpoint.
 """
 
-from pathlib import Path
 import time
 
 from data_pipeline.collectors.twitter_collector import fake_twitter_stream
@@ -16,10 +15,11 @@ from model.inference.adaptive_thresholds import SensitivityController
 from data_pipeline.processors.text_rt_distilbert import RealtimeTextEmbedder
 from service.main import EventHandler
 from utils.io import ensure_dir
+from utils.path_utils import find_repo_root
 
 
 def main():
-    data_dir = ensure_dir(Path(__file__).resolve().parents[1] / "datasets")
+    data_dir = ensure_dir(find_repo_root() / "datasets")
 
     spam_scorer = SpamScorer()
     graph = GraphBuilder(spam_scorer=spam_scorer)

--- a/tests/unit/test_latency_panel.py
+++ b/tests/unit/test_latency_panel.py
@@ -6,9 +6,12 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 import sys
 
+from utils.path_utils import find_repo_root
+
 # Add paths for imports
-dashboard_path = Path(__file__).parent.parent.parent / "dashboard"
-src_path = Path(__file__).parent.parent.parent / "src"
+repo_root = find_repo_root()
+dashboard_path = repo_root / "dashboard"
+src_path = repo_root / "src"
 sys.path.insert(0, str(dashboard_path))
 sys.path.insert(0, str(src_path))
 
@@ -235,9 +238,10 @@ if __name__ == "__main__":
     test_load_hourly_metrics_nonexistent_dir()
     
     print("All latency panel tests passed!")
-    
+
     # Create sample data for manual testing
     print("\nCreating sample test data...")
     test_dir = create_test_metrics_data()
     print(f"Test data created in: {test_dir}")
     print(f"You can test the dashboard with: METRICS_SNAPSHOT_DIR={test_dir}")
+

--- a/tests/unit/test_node_features.py
+++ b/tests/unit/test_node_features.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pytest
-from pathlib import Path
+
+from utils.path_utils import find_repo_root
 
 
 def test_node_features():
     """Test the node features in NPZ file coercible and finite."""
-    path = Path(__file__).parents[1] / "datasets" / "tgn_edges_basic.npz"
+    path = find_repo_root() / "datasets" / "tgn_edges_basic.npz"
     if not path.exists():
         pytest.skip(f"Missing test data: {path}")
 
@@ -31,3 +32,4 @@ def test_node_features():
 
         if arr.size:
             assert np.isfinite(arr).all(), f"Non-finite values at index {i}"
+

--- a/tests/unit/test_npz.py
+++ b/tests/unit/test_npz.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pytest
-from pathlib import Path
+
+from utils.path_utils import find_repo_root
 
 
 def test_npz():
     """Test the NPZ file basic structure and contents."""
-    path = Path(__file__).parents[1] / "datasets" / "tgn_edges_basic.npz"
+    path = find_repo_root() / "datasets" / "tgn_edges_basic.npz"
     if not path.exists():
         pytest.skip(f"Missing test data: {path}")
 
@@ -24,3 +25,4 @@ def test_npz():
     assert src.ndim == dst.ndim == t.ndim == 1
     assert src.size == dst.size == t.size
     assert edge_attr.shape[0] == src.size
+

--- a/tests/unit/test_topk_panel.py
+++ b/tests/unit/test_topk_panel.py
@@ -6,8 +6,11 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 import sys
 
+from utils.path_utils import find_repo_root
+
 # Add paths for imports
-dashboard_path = Path(__file__).parent.parent.parent / "dashboard"
+repo_root = find_repo_root()
+dashboard_path = repo_root / "dashboard"
 sys.path.insert(0, str(dashboard_path))
 
 from dashboard.components.topk import _load_predictions_cache, _format_countdown, _get_latest_predictions
@@ -130,3 +133,4 @@ if __name__ == "__main__":
     test_get_latest_predictions()
     test_get_latest_predictions_empty_cache()
     print("All TopK panel tests passed!")
+


### PR DESCRIPTION
## Summary
- add `find_repo_root` utility to resolve repository root by marker file
- refactor training, service, metrics, and pipeline code to use the shared root finder and `pathlib` paths
- update tests and scripts to rely on the new helper rather than manual `..` navigation

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68bd95bbf1408323a2357913616326b8