### PR TITLE
Add dynamic sidebar countdown for auto-refresh

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -83,10 +83,13 @@ def main():
         else:
             elapsed = now - last
             remaining = max(0, int(interval_s - elapsed))
-            st.sidebar.caption(f"Next refresh in {remaining}s")
-            if elapsed >= interval_s:
-                st.session_state["_last_auto_refresh_ts"] = now
-                st.rerun()
+            counter = st.sidebar.empty()
+            while remaining > 0:
+                counter.caption(f"Next refresh in {remaining}s")
+                time.sleep(1)
+                remaining -= 1
+            st.session_state["_last_auto_refresh_ts"] = time.time()
+            st.rerun()
     
     # Refresh button
     if st.sidebar.button("🔄 Refresh Now"):


### PR DESCRIPTION
## Summary
- Replace static auto-refresh caption with an updating sidebar countdown
- Automatically rerun dashboard when countdown completes

## Testing
- `python -m py_compile dashboard/app.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==2.7.1 --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version because of 403 proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68bf027836ac8323b32e6f7646eb64d0